### PR TITLE
优化界面UI

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@traptitech/markdown-it-katex": "^3.6.0",
     "@vueuse/core": "^9.13.0",
     "axios": "^1.3.4",
+    "clipboard-polyfill": "^4.0.0",
     "echarts": "^5.4.2",
     "file-saver": "^2.0.5",
     "highlight.js": "^11.7.0",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <n-config-provider :theme="theme">
     <n-global-style />
-    <div class="w-full lg:w-screen-lg mx-auto h-screen flex flex-col">
+    <div class="w-full mx-auto h-screen flex flex-col">
       <div class="my-4">
         <PageHeader class="mx-2 lg:mx-0" />
       </div>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3,3 +3,7 @@
     visibility: hidden !important;
   }
 }
+
+::-webkit-scrollbar {
+  display: none;
+}

--- a/frontend/src/views/conversation/components/MessageRow.vue
+++ b/frontend/src/views/conversation/components/MessageRow.vue
@@ -11,8 +11,10 @@
       <n-avatar v-else size="small" :src="chatgptIcon" />
     </div>
     <div class="lt-sm:mx-0 mx-4 w-full">
-      <div v-show="!showRawContent" ref="contentRef" class="message-content w-full" v-html="renderedContent"></div>
-      <div v-show="showRawContent" class="my-3 w-full whitespace-pre-line text-gray-500">{{ props.message.message }}</div>
+      <div v-show="!showRawContent && props.message.author_role != 'user'" ref="contentRef" class="message-content w-full"
+        v-html="renderedContent"></div>
+      <div v-show="showRawContent || props.message.author_role == 'user'"
+        class="my-3 w-full whitespace-pre-line text-gray-500">{{ props.message.message }}</div>
       <div class="hide-in-print">
         <n-button text ghost type="tertiary" size="tiny" class="mt-2 -ml-2 absolute lt-sm:bottom-3 lt-sm:right-3 bottom-1 right-1"
           @click="copyMessageContent">
@@ -42,6 +44,7 @@ import { useI18n } from 'vue-i18n';
 import chatgptIcon from '/chatgpt-icon.svg';
 import chatgptIconBlack from '/chatgpt-icon-black.svg';
 import md from "@/utils/markdown";
+import * as clipboard from "clipboard-polyfill"
 // let md: any;
 // let mdLoaded = ref(false);
 
@@ -143,8 +146,7 @@ const bindOnclick = () => {
   for (const preElement of (preElements as any)) {
     for (const button of preElement.querySelectorAll('button')) {
       (button as HTMLButtonElement).onclick = () => {
-        if (!navigator.clipboard) return;
-        navigator.clipboard
+        clipboard
           .writeText(button.parentElement!.textContent || "")
           .then(function () {
             button.innerHTML = "Copied!";
@@ -176,6 +178,7 @@ const bindOnclick = () => {
 };
 
 const copyMessageContent = () => {
+  /* debugger
   if (!navigator.clipboard) return;
   navigator.clipboard
     .writeText(props.message.message || "")
@@ -183,7 +186,13 @@ const copyMessageContent = () => {
       // console.log('copied', props.message.message);
       Message.success(t('commons.copiedToClipboard'))
     }
-    ).then();
+    ).then(); */
+  const messageContent = props.message.message || '';
+  clipboard.writeText(messageContent).then(() => {
+    Message.success(t('commons.copiedToClipboard'));
+  }).catch(() => {
+    console.error('Failed to copy message content to clipboard.');
+  });
 }
 </script>
 

--- a/frontend/src/views/conversation/index.vue
+++ b/frontend/src/views/conversation/index.vue
@@ -57,7 +57,7 @@
               {{ t("commons.abortRequest") }}
             </n-button>
           </div>
-          <div class="right-4 -top-12 lg:-right-10 lg:-top-8 ml-1 absolute">
+          <div class="right-4 -top-12 ml-1 absolute">
             <!-- 回到底部按钮 -->
             <n-button @click="scrollToBottomSmooth" secondary circle size="small">
               <template #icon>


### PR DESCRIPTION
* 优化全屏拉伸，尤其是在高分辨率屏幕下能拉伸全部宽度
* 优化聊天记录显示，关闭用户消息的默认富文本显示因为在用户发送含大量代码文本消息的时候整个画面显示都是杂乱的
* 修复剪切板无法粘贴问题，用clipboard-polyfill替代让其在非隐私安全情况下也能复制
* 去掉难看的浏览器默认滑动条