### PR TITLE
feat:add reverse_proxy_http_proxy

### DIFF
--- a/backend/utils/proxy.py
+++ b/backend/utils/proxy.py
@@ -22,11 +22,14 @@ def run_reverse_proxy():
 
     puid = config.get("reverse_proxy_puid")
     env_vars = {"PORT": str(config.get("reverse_proxy_port", 6060))}
+    http_proxy = config.get("reverse_proxy_http_proxy")
     if puid:
         env_vars["PUID"] = puid
     if config.get("auto_refresh_reverse_proxy_puid"):
         env_vars["ACCESS_TOKEN"] = config.get("chatgpt_access_token")
-
+    if http_proxy:
+        env_vars["http_proxy"] = http_proxy
+        logger.info(f"Reverse proxy Using http proxy: {http_proxy}")
     g.reverse_proxy_log_file = open(os.path.join(config.get("log_dir", "logs"), "reverse_proxy.log"), "w",
                                     encoding="utf-8")
     logger.debug(f"Reverse proxy binary path: {proxy_path}")


### PR DESCRIPTION
官方ProxyV4支持了http_proxy
https://github.com/acheong08/ChatGPT-Proxy-V4/pull/38/commits/7365fa9fbf2d7a7f09f5732c7683b5814d046950
可以增加http_proxy的环境变量的配置
同时[moeakwak/ChatGPT-Proxy-V4](https://github.com/moeakwak/ChatGPT-Proxy-V4.git)代码需要更新
