### PR TITLE
use new version go-chatgpt-api

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,17 +21,8 @@ services:
   go-chatgpt-api:
     container_name: go-chatgpt-api
     image: linweiyuan/go-chatgpt-api
-    # ports:
-      # - 8080:8080 # 如果你需要暴露端口如一带多，可以取消注释
+    ports:
+      - 8080:8080
     environment:
-      - GIN_MODE=release
-      - CHATGPT_PROXY_SERVER=http://chatgpt-proxy-server:9515
-#      - NETWORK_PROXY_SERVER=http://host:port
-    depends_on:
-      - chatgpt-proxy-server
-    restart: unless-stopped
-
-  chatgpt-proxy-server:
-    container_name: chatgpt-proxy-server
-    image: linweiyuan/chatgpt-proxy-server
+      - GO_CHATGPT_API_PROXY=
     restart: unless-stopped

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
       - ./logs:/app/logs
     environment:
       - TZ=Asia/Shanghai
-      - CHATGPT_BASE_URL=http://go-chatgpt-api:8080
+      - CHATGPT_BASE_URL=http://go-chatgpt-api:8080/chatgpt/
     depends_on:
       - go-chatgpt-api
 


### PR DESCRIPTION
go-chatgpt-api released a new version. It only requires one container to run and reduced resource consumption. 
I have tested it and everything is ok. The new version also has a way to bypass using warp or using your own proxy server.

If you want to continue to use the old version, you need to use this docker tag linweiyuan/go-chatgpt-api:legacy.

