### PR TITLE
将模型枚举由gpt-3.5-turbo-0613修改回gpt-3.5-turbo

### DIFF
--- a/backend/api/enums/models.py
+++ b/backend/api/enums/models.py
@@ -18,7 +18,7 @@ chat_model_definitions = {
         "gpt_4_plugins": "gpt-4-plugins",
     },
     "openai_api": {
-        "gpt_3_5": "gpt-3.5-turbo-0613",
+        "gpt_3_5": "gpt-3.5-turbo",
         "gpt_4": "gpt-4",
     }
 }


### PR DESCRIPTION
根据官方文档描述：
     On June 27th, 2023, gpt-3.5-turbo will be updated to point from gpt-3.5-turbo-0301 to gpt-3.5-turbo-0613.
     2023 年 6 月 27 日，gpt-3.5-turbo 将从 gpt-3.5-turbo-0301 更新为 gpt-3.5-turbo-0613。
文档链接：[https://platform.openai.com/docs/models/gpt-3-5](https://platform.openai.com/docs/models/gpt-3-5)
所以最新的gpt-3.5-turbo与gpt-3.5-turbo-0613保持一致且gpt-3.5-turbo 2023 年 6 月 13 日带有函数调用数据的快照。与 不同 gpt-3.5-turbo ，此模型不会收到更新，并将在新版本发布 3 个月后弃用。