### PR TITLE
fix that per_model_ask_count in admin panel is not showing new model …

### DIFF
--- a/frontend/src/utils/user.ts
+++ b/frontend/src/utils/user.ts
@@ -15,11 +15,13 @@ export const renderUserPerModelCounts = (setting: UserSettingSchema, availableOn
   const openaiWebCounts = {} as Record<string, string>;
   const openaiApiCounts = {} as Record<string, string>;
   openaiWebChatModelNames.forEach((model) => {
-    if (availableOnly && (setting.openai_web.per_model_ask_count[model] == undefined || !setting.openai_web.available_models.includes(model))) return;
+    if (availableOnly && !setting.openai_web.available_models.includes(model)) return;
+    if (setting.openai_web.per_model_ask_count[model] == undefined) setting.openai_web.per_model_ask_count[model] = 0;
     openaiWebCounts[model] = getCountTrans(setting.openai_web.per_model_ask_count[model]);
   });
   openaiApiChatModelNames.forEach((model) => {
-    if (availableOnly && setting.openai_api.per_model_ask_count[model] == undefined || !setting.openai_api.available_models.includes(model)) return;
+    if (availableOnly && !setting.openai_api.available_models.includes(model)) return;
+    if (setting.openai_api.per_model_ask_count[model] == undefined) setting.openai_api.per_model_ask_count[model] = 0;
     openaiApiCounts[model] = getCountTrans(setting.openai_api.per_model_ask_count[model]);
   });
   // console.log(revCounts, apiCounts);


### PR DESCRIPTION
fix that per_model_ask_count in admin panel is not showing new model when upgrading from alpha4.4, even if new model is enabled.