### PR TITLE
Fix file upload button no reaction for mobile devices

### DIFF
--- a/frontend/src/views/conversation/components/FileUploadRegion.vue
+++ b/frontend/src/views/conversation/components/FileUploadRegion.vue
@@ -101,8 +101,8 @@
       :on-before-upload="checkFileBeforeUpload"
       :max="10"
     >
-      <n-upload-trigger abstract>
-        <n-button class="sm:hidden mb-3">
+      <n-upload-trigger>
+        <n-button style="width: 100%;" class="sm:hidden mb-3">
           {{ $t('commons.selectFile') }}
         </n-button>
       </n-upload-trigger>


### PR DESCRIPTION
<img width="399" alt="image" src="https://github.com/chatpire/chatgpt-web-share/assets/3875656/45c82458-bec4-4fb8-9a86-088289a9bb78">

Fix “selectFile” button no reaction in mobile devices by remove `abstract` for `n-upload-trigger` and add a `100%` width style for alignment.