### PR TITLE
会话界面的服务状态卡片能看到GPT-4用量

### DIFF
--- a/frontend/src/views/conversation/components/StatusCard.vue
+++ b/frontend/src/views/conversation/components/StatusCard.vue
@@ -53,6 +53,16 @@
               <div>{{ serverStatus.chatbot_waiting_count }}</div>
             </div>
           </n-list-item>
+          <n-list-item>
+            <div class="flex flex-row justify-between content-center">
+              <div>
+                <n-icon class="mr-1">
+                  <DataUsageRound />
+                </n-icon>{{ $t('labels.gpt4_count_in_3_hours') }}
+              </div>
+              <div>{{ serverStatus.gpt4_count_in_3_hours }}</div>
+            </div>
+          </n-list-item>
         </n-list>
       </n-collapse-item>
     </n-collapse>
@@ -61,7 +71,7 @@
 
 <script setup lang="ts">
 import { MdPeople } from '@vicons/ionicons4';
-import { EventBusyFilled, QueueFilled } from '@vicons/material';
+import { EventBusyFilled, QueueFilled, DataUsageRound } from '@vicons/material';
 import { ref } from 'vue';
 
 import { getServerStatusApi } from '@/api/status';


### PR DESCRIPTION
感觉共同使用的用户还是有必要能看到GPT4当前用量的