### PR TITLE
fix: new conversation source in api mode

### DIFF
--- a/frontend/src/views/conversation/index.vue
+++ b/frontend/src/views/conversation/index.vue
@@ -459,7 +459,7 @@ const sendMsg = async () => {
 
           const newConvHistory = {
             _id: respConversationId!,
-            source: 'openai_web',
+            source: askRequest.source,
             title: currentConvHistory.value!.title,
             current_model: currentConvHistory.value!.current_model,
             create_time: currentConvHistory.value!.create_time,


### PR DESCRIPTION
When starts a new conversation using `API` mode, the conversion title shows it's in `Web` mode when the first conversation finished. After refreshing the page, the title return to `API` mode.

<img width="765" alt="image" src="https://github.com/chatpire/chatgpt-web-share/assets/3875656/f2e6e6be-49e0-45e3-8bd7-ae373f036047">

We should use the source in the request to create new conversation.