### PR TITLE
fix page margin in ios when keyboard popup

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <n-config-provider :locale="locale" :theme="theme">
     <n-global-style />
-    <div class="w-full box-border min-h-screen flex flex-col">
+    <div class="w-full box-border flex flex-col">
       <n-layout>
         <PageHeader v-if="userStore.user" />
         <div style="height: calc(100vh - var(--header-height)); height: calc(100dvh - var(--header-height))">


### PR DESCRIPTION
In ios, when the keyboard popup, the page height is not set properly, with a few empty lines between the keyboard and the textarea. Remove the `min-h-screen` will fixed the issue.