### PR TITLE
fix invalid parent message id after user abort request in api mode

### DIFF
--- a/backend/api/routers/chat.py
+++ b/backend/api/routers/chat.py
@@ -433,11 +433,16 @@ async def chat(websocket: WebSocket):
         websocket_reason = "errors.httpError"
     except Exception as e:
         logger.error(with_traceback(e))
-        await reply(AskResponse(
-            type=AskResponseType.error,
-            tip="errors.unknownError",
-            error_detail=str(e)
-        ))
+        is_canceled = True
+        try:
+            await reply(AskResponse(
+                type=AskResponseType.error,
+                tip="errors.unknownError",
+                error_detail=str(e)
+            ))
+        except Exception as e:
+            # Ignore exception, websocket may be already closed.
+            pass
         websocket_code = 1011
         websocket_reason = "errors.unknownError"
 


### PR DESCRIPTION
When user abort receving reply during response, websocket will be closed in client side, it will cause exception in server reply. But in the exception handling, reply to websocket will generate a nested exception that result to the following code can not be executed.

So we should wrap the `reply` with `try..except`( we can just ignore the error) during exception handling.