### PR TITLE
Fix compatibility for gen_title in web

### DIFF
--- a/backend/api/models/doc/__init__.py
+++ b/backend/api/models/doc/__init__.py
@@ -174,7 +174,7 @@ class OpenaiApiChatMessageTextContent(BaseModel):
 class BaseChatMessage(BaseModel):
     id: uuid.UUID
     source: SourceTypeLiteral
-    role: Literal['system', 'user', 'assistant', 'tool'] | str
+    role: Optional[Literal['system', 'user', 'assistant', 'tool'] | str] = None
     author_name: Optional[Literal['browser', 'python'] | str] = None  # rev: mapping[id].message.author.name
     model: Optional[str] = None  # rev: mapping[id].message.metadata.model_slug -> ChatModel
     create_time: Optional[datetime.datetime] = None
@@ -184,6 +184,7 @@ class BaseChatMessage(BaseModel):
     metadata: Optional[
         Annotated[
             Union[OpenaiWebChatMessageMetadata, OpenaiApiChatMessageMetadata], Field(discriminator='source')]] = None
+    title: Optional[str] = None
 
 
 class OpenaiWebChatMessage(BaseChatMessage):

--- a/backend/api/routers/conv.py
+++ b/backend/api/routers/conv.py
@@ -164,8 +164,9 @@ async def vanish_conversation(conversation: BaseConversation = Depends(_get_conv
 async def update_conversation_title(title: str, conversation: BaseConversation = Depends(_get_conversation_by_id),
                                     user: User = Depends(current_active_user)):
     if conversation.source == ChatSourceTypes.openai_web:
-        await openai_web_manager.set_conversation_title(conversation.conversation_id,
-                                                        title, conversation.source_id)
+        pass
+        #await openai_web_manager.set_conversation_title(conversation.conversation_id,
+        #                                                title, conversation.source_id)
     else:  # api
         doc = await OpenaiApiConversationHistoryDocument.get(conversation.conversation_id)
         if doc is None:

--- a/backend/api/sources/openai_web.py
+++ b/backend/api/sources/openai_web.py
@@ -38,6 +38,14 @@ logger = get_logger(__name__)
 
 
 def convert_openai_web_message(item: dict, message_id: str = None) -> OpenaiWebChatMessage | None:
+    if item.get("type") == "title_generation":
+        result = OpenaiWebChatMessage(
+            id='3aa263a5-6acf-4975-b7e8-7a8c85bf5167',
+            source="openai_web",
+            children=[],
+            title=item.get("title"),
+        )
+        return result
     if not item.get("message"):
         return None
     if not item["message"].get("author"):
@@ -123,6 +131,8 @@ def get_latest_model_from_mapping(current_node_uuid: str | None,
 
 def _check_fields(data: dict) -> bool:
     try:
+        if "type" in data and data["type"] == "title_generation":
+            return True
         data["message"]["content"]
     except (TypeError, KeyError):
         return False

--- a/frontend/src/types/openapi.ts
+++ b/frontend/src/types/openapi.ts
@@ -364,6 +364,7 @@ export interface components {
       content?: (components["schemas"]["OpenaiWebChatMessageTextContent"] | components["schemas"]["OpenaiWebChatMessageMultimodalTextContent"] | components["schemas"]["OpenaiWebChatMessageCodeContent"] | components["schemas"]["OpenaiWebChatMessageExecutionOutputContent"] | components["schemas"]["OpenaiWebChatMessageStderrContent"] | components["schemas"]["OpenaiWebChatMessageTetherBrowsingDisplayContent"] | components["schemas"]["OpenaiWebChatMessageTetherQuoteContent"] | components["schemas"]["OpenaiWebChatMessageSystemErrorContent"]) | components["schemas"]["OpenaiApiChatMessageTextContent"] | null;
       /** Metadata */
       metadata?: (components["schemas"]["OpenaiWebChatMessageMetadata"] | components["schemas"]["OpenaiApiChatMessageMetadata"]) | null;
+      title?: string | null;
     };
     /** BaseConversationHistory */
     BaseConversationHistory: {


### PR DESCRIPTION
Now the new conversation title will be sent via wss from server to client directly. If we get the title during receiving messages from wss, we can save the title to db without call `gen_title` api.